### PR TITLE
ci: add GitHub Actions build workflow + minor cleanup

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -30,6 +30,7 @@ jobs:
           pyinstaller --clean --noconsole --onedir --icon="SilverSpoon.ico"
           --add-binary "7z.exe;." --add-binary "7z.dll;."
           --add-data "SilverSpoon.ico;." --add-data "SilverSpoon.png;."
+          --copy-metadata "curl_cffi"
           --name "SilverSpoon" pyqt_downloader.py
 
       - name: Bundle Playwright Chromium into dist
@@ -49,7 +50,7 @@ jobs:
 
       - name: Zip distribution
         shell: pwsh
-        run: Compress-Archive -Path 'dist\SilverSpoon\*' -DestinationPath 'SilverSpoon-windows.zip'
+        run: Compress-Archive -Path 'dist\SilverSpoon' -DestinationPath 'SilverSpoon-windows.zip'
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -1,0 +1,64 @@
+name: Build Windows Executable
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller playwright
+
+      - name: Install Playwright Chromium
+        run: python -m playwright install chromium
+
+      - name: Build with PyInstaller
+        run: >
+          pyinstaller --clean --noconsole --onedir --icon="SilverSpoon.ico"
+          --add-binary "7z.exe;." --add-binary "7z.dll;."
+          --add-data "SilverSpoon.ico;." --add-data "SilverSpoon.png;."
+          --name "SilverSpoon" pyqt_downloader.py
+
+      - name: Bundle Playwright Chromium into dist
+        shell: pwsh
+        run: |
+          $source = Get-ChildItem (Join-Path $env:LOCALAPPDATA 'ms-playwright') -Directory -Filter 'chromium-*' |
+            Where-Object { $_.Name -notlike 'chromium_headless*' } |
+            Sort-Object Name -Descending |
+            ForEach-Object { Join-Path $_.FullName 'chrome-win64' } |
+            Where-Object { Test-Path (Join-Path $_ 'chrome.exe') } |
+            Select-Object -First 1
+          if (-not $source) {
+            Write-Error 'Playwright Chromium was not found under %LOCALAPPDATA%\ms-playwright.'
+            exit 1
+          }
+          Copy-Item -LiteralPath $source -Destination 'dist\SilverSpoon\playwright-chromium' -Recurse -Force
+
+      - name: Zip distribution
+        shell: pwsh
+        run: Compress-Archive -Path 'dist\SilverSpoon\*' -DestinationPath 'SilverSpoon-windows.zip'
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SilverSpoon-windows
+          path: SilverSpoon-windows.zip
+
+      - name: Attach to release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: SilverSpoon-windows.zip

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -714,10 +714,8 @@ class MainWindow(QMainWindow):
             if sys.platform == 'win32':
                 os.startfile(folder_path)
             elif sys.platform == 'darwin':
-                import subprocess
                 subprocess.Popen(['open', folder_path])
             else:
-                import subprocess
                 subprocess.Popen(['xdg-open', folder_path])
         except Exception as e:
             QMessageBox.critical(self, "Error", f"Could not open folder:\n{e}")
@@ -1663,7 +1661,6 @@ class MainWindow(QMainWindow):
                     extractor_type = '7z'
                     base_cmd = bundled_7z
             else:
-                import shutil
                 if shutil.which('7z'):
                     extractor_type = '7z'
                     base_cmd = '7z'


### PR DESCRIPTION
## What
- Adds `.github/workflows/build-exe.yml`, automating the `build_exe.bat` steps (PyInstaller + bundling Playwright Chromium) in CI. Runs on manual dispatch and on `v*.*.*` tags, uploads the zipped `dist` folder as a build artifact and attaches it to the GitHub release when triggered by a tag.
- Removes 3 redundant function-local `import subprocess` / `import shutil` statements in `pyqt_downloader.py` — both are already imported at module level. No behavior change.

## Why
Right now the release `.exe` is only ever hand-built and manually uploaded, so there's no reproducible/verifiable build tying a release asset back to the exact source commit. This gives every tagged release an auditable CI build trail.

## Testing
- Ran the equivalent commands locally (pip install deps, playwright install chromium, PyInstaller build) and diffed the resulting `dist\SilverSpoon` against the published v1.4.0 release: identical `_internal` file listing, byte-identical `7z.exe`/`7z.dll`/`curl_cffi` native binary hashes.
- `python -m py_compile pyqt_downloader.py` passes after the import cleanup.