### PR TITLE
fix(ui): responsive action buttons (hover/pressed feedback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixes & Improvements
+* **Responsive Action Buttons**: The action buttons (Add, Start/Resume, Pause, Cancel, Retry, Force Redownload, Copy Error Details, Delete) now show hover, pressed, and disabled states, so a click gives immediate visual feedback instead of looking unresponsive. Button colors are unchanged.
+
 ## [v1.4.0] - 2026-08-03
 
 ### New Features

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -60,6 +60,7 @@ from curl_cffi import requests as curl_requests
 from cf_turnstile import TurnstileSolver
 from PyQt6.QtCore import QMetaObject, Q_ARG
 from update_logic import UpdateCheckerThread, UpdateDownloaderDialog
+from ui_style import button_style
 
 CURRENT_VERSION = "v1.4.0"
 GITHUB_REPO = "billysams21/SilverSpoon"
@@ -130,6 +131,7 @@ def format_error_message(error, max_length=160):
     if len(text) > max_length:
         text = text[:max_length].rstrip() + "..."
     return f"{error_type}: {text}"
+
 
 class WarningDialog(QDialog):
     def __init__(self, settings, parent=None):
@@ -520,7 +522,7 @@ class MainWindow(QMainWindow):
         main_layout.addWidget(self.text_links)
         
         add_btn = QPushButton("Add Links to Queue")
-        add_btn.setStyleSheet("background-color: #2e55cc; color: white; font-weight: bold; padding: 6px;")
+        add_btn.setStyleSheet(button_style("#2e55cc"))
         add_btn.clicked.connect(self.add_links)
         main_layout.addWidget(add_btn)
 
@@ -579,37 +581,37 @@ class MainWindow(QMainWindow):
         action_layout.addWidget(self.select_all_btn)
         
         self.start_btn = QPushButton("Start / Resume")
-        self.start_btn.setStyleSheet("background-color: #2ecc71; color: white; font-weight: bold; padding: 6px;")
+        self.start_btn.setStyleSheet(button_style("#2ecc71"))
         self.start_btn.clicked.connect(self.start_downloads)
         action_layout.addWidget(self.start_btn)
         
         self.pause_btn = QPushButton("Pause")
-        self.pause_btn.setStyleSheet("background-color: #f39c12; color: white; font-weight: bold; padding: 6px;")
+        self.pause_btn.setStyleSheet(button_style("#f39c12"))
         self.pause_btn.clicked.connect(self.pause_selected)
         action_layout.addWidget(self.pause_btn)
         
         self.cancel_btn = QPushButton("Cancel")
-        self.cancel_btn.setStyleSheet("background-color: #e74c3c; color: white; font-weight: bold; padding: 6px;")
+        self.cancel_btn.setStyleSheet(button_style("#e74c3c"))
         self.cancel_btn.clicked.connect(self.cancel_selected)
         action_layout.addWidget(self.cancel_btn)
         
         self.retry_btn = QPushButton("Retry")
-        self.retry_btn.setStyleSheet("background-color: #9b59b6; color: white; font-weight: bold; padding: 6px;")
+        self.retry_btn.setStyleSheet(button_style("#9b59b6"))
         self.retry_btn.clicked.connect(self.retry_selected)
         action_layout.addWidget(self.retry_btn)
 
         self.force_redownload_btn = QPushButton("Force Redownload")
-        self.force_redownload_btn.setStyleSheet("background-color: #300101; color: white; font-weight: bold; padding: 6px;")
+        self.force_redownload_btn.setStyleSheet(button_style("#300101"))
         self.force_redownload_btn.clicked.connect(self.force_redownload_selected)
         action_layout.addWidget(self.force_redownload_btn)
 
         self.copy_log_btn = QPushButton("Copy Error Details")
-        self.copy_log_btn.setStyleSheet("background-color: #555; color: white; font-weight: bold; padding: 6px;")
+        self.copy_log_btn.setStyleSheet(button_style("#555"))
         self.copy_log_btn.clicked.connect(self.copy_selected_error_log)
         action_layout.addWidget(self.copy_log_btn)
         
         self.delete_btn = QPushButton("🗑️ Delete")
-        self.delete_btn.setStyleSheet("background-color: #34495e; color: white; font-weight: bold; padding: 6px;")
+        self.delete_btn.setStyleSheet(button_style("#34495e"))
         self.delete_btn.clicked.connect(self.delete_selected)
         action_layout.addWidget(self.delete_btn)
         

--- a/test_button_style.py
+++ b/test_button_style.py
@@ -1,0 +1,40 @@
+"""Headless checks for the button-style helpers. Run: python test_button_style.py
+
+These are pure string/color functions (no Qt needed), so the hover/pressed
+derivation and hex handling are pinned without a display.
+"""
+import ui_style as P
+
+
+def test_shade_expands_shorthand():
+    assert P._shade("#555", 1.0) == "#555555"
+
+
+def test_shade_clamps_high_and_low():
+    assert P._shade("#ffffff", 1.5) == "#ffffff"   # clamp at 255
+    assert P._shade("#000000", 0.5) == "#000000"   # stays at 0
+
+
+def test_shade_darkens_and_lightens():
+    dark = P._shade("#2ecc71", 0.82)
+    light = P._shade("#2ecc71", 1.12)
+    # darkening lowers each channel, lightening raises it
+    assert int(dark[1:3], 16) < 0x2e < int(light[1:3], 16)
+    assert len(dark) == 7 and dark.startswith("#")
+
+
+def test_button_style_has_all_states():
+    qss = P.button_style("#2ecc71")
+    for token in ("QPushButton", ":hover", ":pressed", ":disabled",
+                  "#2ecc71", "border-radius"):
+        assert token in qss, token
+    # pressed keeps height constant: top+1 / bottom-1 around the 6px base
+    assert "padding-top: 7px" in qss and "padding-bottom: 5px" in qss
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")

--- a/ui_style.py
+++ b/ui_style.py
@@ -5,7 +5,12 @@ Kept import-light (pure string/color math) so it is unit-testable headlessly.
 
 
 def _shade(hex_color, factor):
-    """Lighten (factor>1) or darken (factor<1) a #rgb/#rrggbb color, clamped."""
+    """Lighten (factor>1) or darken (factor<1) a #rgb/#rrggbb color, clamped.
+
+    Hex input only (`#rgb` or `#rrggbb`) — named colors or `#rgba` raise
+    ValueError. All call sites pass literal hex; validate at the call site if
+    that ever changes.
+    """
     h = hex_color.lstrip("#")
     if len(h) == 3:                       # expand shorthand, e.g. 555 -> 555555
         h = "".join(c * 2 for c in h)
@@ -14,22 +19,27 @@ def _shade(hex_color, factor):
     return f"#{r:02x}{g:02x}{b:02x}"
 
 
-def button_style(base, fg="white", padding_v=6, padding_h=12):
+def button_style(base, fg="white", padding_v=6, padding_h=6):
     """Stylesheet for an action button with visible hover/pressed/disabled
-    states derived from its base color, so clicks feel responsive.
+    states, so clicks feel responsive.
 
-    Flat inline `background-color` styles suppress Qt's native press feedback;
-    this restores it (and adds a 1px 'push-down' on press that keeps total
-    padding — and therefore button height — constant, so nothing reflows).
+    Hover and pressed backgrounds are derived from `base` (lighter / darker);
+    the disabled state uses a fixed neutral grey. Flat inline `background-color`
+    styles suppress Qt's native press feedback; this restores it (and adds a 1px
+    'push-down' on press that keeps total padding — and therefore button height —
+    constant, so nothing reflows). Defaults match the previous `padding: 6px`
+    (6px on all sides) so button sizing is unchanged.
     """
     hover = _shade(base, 1.12)
     pressed = _shade(base, 0.82)
     return (
         f"QPushButton {{ background-color: {base}; color: {fg}; font-weight: bold;"
         f" border: none; border-radius: 4px;"
-        f" padding: {padding_v}px {padding_h}px; }}"
-        f"QPushButton:hover {{ background-color: {hover}; }}"
+        f" padding: {padding_v}px {padding_h}px; }}\n"
+        f"QPushButton:hover {{ background-color: {hover}; }}\n"
         f"QPushButton:pressed {{ background-color: {pressed};"
-        f" padding-top: {padding_v + 1}px; padding-bottom: {padding_v - 1}px; }}"
-        f"QPushButton:disabled {{ background-color: #9aa0a6; color: #e6e6e6; }}"
+        f" padding-top: {padding_v + 1}px; padding-bottom: {padding_v - 1}px; }}\n"
+        # Fixed neutral grey; ~4:1 contrast (white on #6c757d) clears WCAG's 3:1
+        # floor for UI components.
+        f"QPushButton:disabled {{ background-color: #6c757d; color: #ffffff; }}"
     )

--- a/ui_style.py
+++ b/ui_style.py
@@ -1,0 +1,35 @@
+"""Small, Qt-free stylesheet helpers for the GUI.
+
+Kept import-light (pure string/color math) so it is unit-testable headlessly.
+"""
+
+
+def _shade(hex_color, factor):
+    """Lighten (factor>1) or darken (factor<1) a #rgb/#rrggbb color, clamped."""
+    h = hex_color.lstrip("#")
+    if len(h) == 3:                       # expand shorthand, e.g. 555 -> 555555
+        h = "".join(c * 2 for c in h)
+    r, g, b = (int(h[i:i + 2], 16) for i in (0, 2, 4))
+    r, g, b = (max(0, min(255, round(c * factor))) for c in (r, g, b))
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def button_style(base, fg="white", padding_v=6, padding_h=12):
+    """Stylesheet for an action button with visible hover/pressed/disabled
+    states derived from its base color, so clicks feel responsive.
+
+    Flat inline `background-color` styles suppress Qt's native press feedback;
+    this restores it (and adds a 1px 'push-down' on press that keeps total
+    padding — and therefore button height — constant, so nothing reflows).
+    """
+    hover = _shade(base, 1.12)
+    pressed = _shade(base, 0.82)
+    return (
+        f"QPushButton {{ background-color: {base}; color: {fg}; font-weight: bold;"
+        f" border: none; border-radius: 4px;"
+        f" padding: {padding_v}px {padding_h}px; }}"
+        f"QPushButton:hover {{ background-color: {hover}; }}"
+        f"QPushButton:pressed {{ background-color: {pressed};"
+        f" padding-top: {padding_v + 1}px; padding-bottom: {padding_v - 1}px; }}"
+        f"QPushButton:disabled {{ background-color: #9aa0a6; color: #e6e6e6; }}"
+    )


### PR DESCRIPTION
## Summary

The main action buttons felt unresponsive — clicking one gave **no visual feedback** even though the action fired, so the UI looked dead.

**Root cause:** each action button sets a flat inline `background-color` stylesheet. A widget-level `background-color` overrides Qt's native button styling, which also removes its built-in pressed animation — and no `:hover`/`:pressed` states were provided to replace it. (The unstyled buttons like *Browse* and *Select All* still animated, which is why only some buttons felt dead.)

**Fix:** a small, Qt-free `button_style(base_color)` helper (new `ui_style.py`) derives `:hover` (lighter), `:pressed` (darker, with a 1px "push-down"), and `:disabled` states from each button's existing color. All eight styled buttons now use it. **Colors are unchanged** — only the missing states are added. The press push-down shifts the label down 1px while keeping total vertical padding constant, so button height doesn't change and nothing reflows.

## Motivation

Immediate click feedback is a basic affordance; without it users double-click or assume the app is frozen.

## Impacts / backward compatibility

- **New file** `ui_style.py` (pure string/color helpers, no Qt import) + **new** `test_button_style.py`.
- `pyqt_downloader.py`: replaces 8 inline button stylesheets with `button_style(...)` calls and adds one import. No behavior or color changes.
- **No new dependencies.**

## How verified

- `python test_button_style.py` — 4 checks: shorthand hex expansion (`#555`→`#555555`), channel clamping, darken/lighten direction, and that the generated QSS contains all four states with the height-preserving pressed padding.
- Offscreen (Qt `offscreen`) smoke: `pyqt_downloader` imports with the new helper, and Qt parses & paints the stylesheet for all 8 button colors with **no QSS parse warnings**.

> Best verified visually with a manual run, but the color math and QSS validity are covered headlessly.

## Files changed

- `ui_style.py` (new) — `button_style()` + `_shade()`.
- `test_button_style.py` (new) — headless checks.
- `pyqt_downloader.py` — use the helper for the 8 action buttons.
- `CHANGELOG.md` — Unreleased fix entry.
