### PR TITLE
v1.5.5: queue-based updater, general direct-URL downloads, solver teardown, status pill fix, working release CI

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: write   # required for the release-attach step to upload the zip
     steps:
       - uses: actions/checkout@v4
 
@@ -44,16 +46,14 @@ jobs:
       - name: Bundle Playwright Chromium into dist
         shell: pwsh
         run: |
-          $source = Get-ChildItem (Join-Path $env:LOCALAPPDATA 'ms-playwright') -Directory -Filter 'chromium-*' |
-            Where-Object { $_.Name -notlike 'chromium_headless*' } |
-            Sort-Object Name -Descending |
-            ForEach-Object { Join-Path $_.FullName 'chrome-win64' } |
-            Where-Object { Test-Path (Join-Path $_ 'chrome.exe') } |
-            Select-Object -First 1
-          if (-not $source) {
-            Write-Error 'Playwright Chromium was not found under %LOCALAPPDATA%\ms-playwright.'
+          # Ask Playwright itself for the chromium executable path — robust across
+          # Playwright versions / Chrome-for-Testing layouts (the old glob broke).
+          $exe = (python -c "from playwright.sync_api import sync_playwright; p=sync_playwright().start(); print(p.chromium.executable_path); p.stop()").Trim()
+          if (-not $exe -or -not (Test-Path $exe)) {
+            Write-Error "Playwright Chromium executable not found (got '$exe')."
             exit 1
           }
+          $source = Split-Path $exe -Parent   # the chrome-win64 dir holding chrome.exe
           $dest = 'dist\SilverSpoon\playwright-chromium'
           if (Test-Path $dest) { Remove-Item $dest -Recurse -Force }
           New-Item -ItemType Directory -Path $dest -Force | Out-Null

--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -64,6 +64,23 @@ jobs:
             if (Test-Path $p) { Remove-Item $p -Force }
           }
 
+      - name: Verify bundle is complete
+        shell: pwsh
+        run: |
+          # Fail loudly instead of shipping a build that crashes on launch.
+          if (-not (Test-Path 'dist\SilverSpoon\SilverSpoon.exe')) {
+            Write-Error 'Bundle incomplete: SilverSpoon.exe missing.'; exit 1
+          }
+          # curl_cffi reads its own package metadata at import; without the
+          # copied .dist-info the app dies with PackageNotFoundError on startup.
+          if (-not (Get-ChildItem 'dist\SilverSpoon\_internal' -Filter 'curl_cffi-*.dist-info' -Directory -ErrorAction SilentlyContinue)) {
+            Write-Error 'Bundle incomplete: curl_cffi metadata (.dist-info) missing -> app would crash on launch.'; exit 1
+          }
+          if (-not (Test-Path 'dist\SilverSpoon\playwright-chromium\chrome.exe')) {
+            Write-Error 'Bundle incomplete: bundled Chromium (chrome.exe) missing.'; exit 1
+          }
+          Write-Host 'Bundle verified: exe + curl_cffi metadata + chromium all present.'
+
       - name: Zip distribution
         shell: pwsh
         run: Compress-Archive -Path 'dist\SilverSpoon' -DestinationPath 'SilverSpoon-windows.zip'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixes & Improvements
+* **Updates download in the queue (no more crash):** The auto-updater no longer uses a separate modal downloader (which could crash mid-download on large releases). A new version is now added to your normal download queue — start it when you like, and pause/resume it like any other download. When it finishes, choose **Install now** (restart) or **Install on next open**; a deferred update is offered again the next time you launch. Update downloads skip the Cloudflare/CAPTCHA step and are never auto-extracted.
+
 ## [v1.5.0] - 2026-08-21
 
 ### New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v1.5.5] - 2026-09-08
 
 ### New Features
 * **General Direct-URL Downloads**: Any link whose host isn't a Cloudflare/Turnstile provider (FuckingFast, DataNodes) now downloads straight over HTTP with resume/pause/progress — the queue is no longer limited to those providers. FuckingFast and DataNodes links still go through the Turnstile solver exactly as before.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # SilverSpoon (previously FitGirlDownloader)
 
-> **Note:** Currently supports `fuckingfast.co` and `datanodes.to` links (commonly used by FitGirl Repacks and direct download mirrors). Support for additional hosts may be added in the future.
+> **Note:** `fuckingfast.co` and `datanodes.to` links (commonly used by FitGirl Repacks and direct download mirrors) go through the built-in Cloudflare Turnstile solver. Since v1.5.5 any other plain `http(s)` direct link is downloaded straight away, with the same pause/resume/progress support.
 
-A Python-based bulk downloader designed to bypass Cloudflare protections on file-hosting sites like *fuckingfast.co* and *datanodes.to*. It automates the process of extracting direct download links and supports concurrent downloading with pause and resume capabilities.
+A Python-based bulk downloader designed to bypass Cloudflare protections on file-hosting sites like *fuckingfast.co* and *datanodes.to*, and to queue ordinary direct download links alongside them. It automates the process of extracting direct download links and supports concurrent downloading with pause and resume capabilities.
 
 ## Features
 
-* **Auto-Updater:** (Windows only) Automatically checks for, downloads, and applies new updates so you are always on the latest version without manual `.zip` downloads.
+* **Auto-Updater:** (Windows only) Checks for new releases on launch (or via `Help -> Check for Updates...`). An update is added to your normal download queue — start, pause and resume it like any other task; it saves to your Save-To folder and skips the CAPTCHA step. When it finishes, choose **Install now** (restart) or **Install on next open**.
+* **General Direct-URL Downloads:** Any link whose host isn't a Turnstile-protected provider is downloaded directly over HTTP with resume, pause and progress — the queue is not limited to FuckingFast/DataNodes.
 * **Cross-Platform Extraction:** Built-in auto-extraction support for Windows (bundled `7z`), as well as Linux and macOS (via `/usr/bin/7z` / `p7zip`).
-* **Cloudflare Turnstile Bypass:** Uses a hidden Chromium browser (via `nodriver`) to auto-solve Cloudflare Turnstile challenges invisibly, then downloads via `curl_cffi` with TLS impersonation. No manual CAPTCHA solving needed for normal IPs.
+* **Cloudflare Turnstile Bypass:** Uses a hidden Chromium browser (via `nodriver`) to auto-solve Cloudflare Turnstile challenges invisibly, then downloads via `curl_cffi` with TLS impersonation. No manual CAPTCHA solving needed for normal IPs. A failed resolution tears the browser down instead of reusing a broken one, so Chromium no longer re-spawns endlessly.
 * **Persistent Download History:** Automatically saves your task queue, progress, and folder groupings across sessions. Close the app anytime without losing your place!
 * **Grouped Batch Folders:** Downloads are neatly organized into collapsible dropdown trees, showing aggregated progress, speed, and ETA for entire batches.
 * **Smart Folder Grouping & Batching:** Automatically suggests a unified folder name for a batch of links, perfectly grouping main game parts and messy optional files together.
@@ -57,7 +58,7 @@ python pyqt_downloader.py
 ![App Screenshot 1](assets/screenshot1.png)
 
 1. Click **Browse...** to select your base save directory (or set a persistent default in `File -> Settings`).
-2. Open the game link and click the provider you want to use (for now it's FuckingFast).
+2. Open the game link and click the provider you want to use (FuckingFast or DataNodes). Plain direct links from any other host can be pasted as-is.
 ![FitGirl 1](assets/fitgirl1.png)
 3. Copy the links you want to download.
 ![FitGirl 2](assets/fitgirl2.png)
@@ -91,6 +92,10 @@ If you prefer the command line:
    python downloader.py link.txt
    ```
 *(Files will be downloaded to the current working directory).*
+
+## Building the Windows executable
+
+Run `build_exe.bat` (needs `pyinstaller` and a Playwright Chromium under `%LOCALAPPDATA%\ms-playwright`); the distributable folder lands in `dist\SilverSpoon`. Pushing a `v*.*.*` tag runs the same build on GitHub Actions and attaches `SilverSpoon-windows.zip` to the release.
 
 ## Contributing
 

--- a/cf_turnstile.py
+++ b/cf_turnstile.py
@@ -358,7 +358,18 @@ class TurnstileSolver:
             return {"direct_url": direct_url, "cookies": cookies, "user_agent": user_agent}
 
     def get_direct_link(self, link):
-        return self._submit(self._resolve_direct_link_async(link))
+        return self._submit(self._resolve_with_cleanup(link))
+
+    async def _resolve_with_cleanup(self, link):
+        try:
+            return await self._resolve_direct_link_async(link)
+        except Exception:
+            # Any failed resolution tears the browser down so a broken instance
+            # is never reused — reuse was causing repeated browser re-spawns that
+            # never reached the download page.
+            async with self._browser_lock:
+                await self._close_browser()
+            raise
 
     @property
     def user_agent(self):

--- a/providers.py
+++ b/providers.py
@@ -1,0 +1,22 @@
+"""Provider/host classification for the downloader.
+
+Kept Qt-free (stdlib only) so it can be unit-tested headlessly. Hosts that hide
+the file behind a Cloudflare/Turnstile challenge need the solver to extract a
+direct link; every other host is treated as a plain, direct HTTP download.
+"""
+import urllib.parse
+
+# Hosts handled by the Turnstile/CAPTCHA solver (cf_turnstile). Keep in sync
+# with the providers cf_turnstile.py actually supports.
+RESOLVER_HOSTS = ("fuckingfast.co", "datanodes.to")
+
+
+def needs_resolution(link):
+    """True if the link's host must go through the Turnstile/CAPTCHA solver."""
+    try:
+        host = urllib.parse.urlparse(link).netloc.lower()
+    except Exception:
+        return False
+    if host.startswith("www."):
+        host = host[4:]
+    return any(host == h or host.endswith("." + h) for h in RESOLVER_HOSTS)

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -13,6 +13,7 @@ import shutil
 import uuid
 import urllib.request
 import urllib.error
+import urllib.parse
 from collections import deque
 
 logging.basicConfig(
@@ -435,6 +436,22 @@ from ui_style import button_style
 
 CURRENT_VERSION = "v1.5.0"
 GITHUB_REPO = "billysams21/SilverSpoon"
+
+# Hosts that hide the file behind a Cloudflare/Turnstile challenge and need the
+# solver to extract a direct link. Every other host is treated as a plain,
+# direct download (fetched straight over HTTP). Keep FuckingFast + DataNodes.
+RESOLVER_HOSTS = ("fuckingfast.co", "datanodes.to")
+
+
+def needs_resolution(link):
+    """True if the link's host needs the Turnstile/CAPTCHA solver."""
+    try:
+        host = urllib.parse.urlparse(link).netloc.lower()
+    except Exception:
+        return False
+    if host.startswith("www."):
+        host = host[4:]
+    return any(host == h or host.endswith("." + h) for h in RESOLVER_HOSTS)
 
 def get_settings_path():
     return os.path.expanduser("~/.silverspoon_settings.json")
@@ -1177,7 +1194,7 @@ class MainWindow(QMainWindow):
         left_layout.addLayout(left_header)
 
         self.text_links = QTextEdit()
-        self.text_links.setPlaceholderText("Paste one or multiple FuckingFast URLs here...")
+        self.text_links.setPlaceholderText("Paste FuckingFast / DataNodes links or any direct download URLs here...")
         self.text_links.setAcceptRichText(False)
         self.text_links.setFixedHeight(77)
         self.text_links.installEventFilter(self)
@@ -2801,10 +2818,11 @@ class MainWindow(QMainWindow):
             task.error_message = "Could not get the direct download link. The link may be expired or blocked."
         return None
 
-    def _download_update_file(self, task):
-        """Download an app-update file via urllib (stdlib), with resume,
-        pause/cancel and progress. Kept off the shared curl_cffi session, which
-        hangs (curl 28) for a manager-spawned worker that skips get_direct_link."""
+    def _download_direct_file(self, task):
+        """Download a plain, direct URL via urllib (stdlib), with resume,
+        pause/cancel and progress. Used for app updates and any non-resolver
+        host. Kept off the shared curl_cffi session, which hangs (curl 28) for a
+        manager-spawned worker that skips the get_direct_link/nodriver path."""
         try:
             os.makedirs(task.save_dir, exist_ok=True)
         except Exception as e:
@@ -2817,7 +2835,7 @@ class MainWindow(QMainWindow):
 
         initial_size = os.path.getsize(task.filepath) if os.path.exists(task.filepath) else 0
         req = urllib.request.Request(
-            task.link, headers={"User-Agent": f"SilverSpoon-Updater/{CURRENT_VERSION}"})
+            task.link, headers={"User-Agent": f"SilverSpoon/{CURRENT_VERSION}"})
         if initial_size > 0:
             req.add_header("Range", f"bytes={initial_size}-")
 
@@ -2897,12 +2915,11 @@ class MainWindow(QMainWindow):
         self.trigger_history_save()
 
     def download_worker(self, task):
-        if getattr(task, "is_update", False):
-            # App updates are plain, direct URLs downloaded via urllib (stdlib).
-            # The shared curl_cffi session hangs (curl 28) when a manager-spawned
-            # worker uses it for a request that never went through the
-            # nodriver/get_direct_link path first; urllib is unaffected.
-            self._download_update_file(task)
+        # App updates and any non-resolver (general direct) URL download straight
+        # over HTTP via urllib. Only FuckingFast/DataNodes-style links go through
+        # the Turnstile/CAPTCHA solver + curl transport, exactly as before.
+        if getattr(task, "is_update", False) or not needs_resolution(task.link):
+            self._download_direct_file(task)
             return
 
         dl_url = self.get_direct_link(task)

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -426,7 +426,7 @@ ProgressBarDelegate = ModernTaskDelegate
 from curl_cffi import requests as curl_requests
 from cf_turnstile import TurnstileSolver
 from PyQt6.QtCore import QMetaObject, Q_ARG
-from update_logic import UpdateCheckerThread, UpdateDownloaderDialog
+from update_logic import UpdateCheckerThread
 import datetime as _dt
 import scheduler as offpeak
 from ui_style import button_style
@@ -927,6 +927,11 @@ class DownloadTask:
         self.tree_item = None
         self.is_selected = False
 
+        # App-update tasks download a plain URL (no CAPTCHA/direct-link step)
+        # and, once complete, offer to install instead of being extracted.
+        self.is_update = False
+        self.update_version = None
+
     def to_dict(self):
         return {
             "uid": self.uid,
@@ -937,7 +942,9 @@ class DownloadTask:
             "error_message": self.error_message,
             "downloaded_bytes": self.downloaded_bytes,
             "total_bytes": self.total_bytes,
-            "progress": self.progress
+            "progress": self.progress,
+            "is_update": self.is_update,
+            "update_version": self.update_version
         }
         
     @classmethod
@@ -958,6 +965,8 @@ class DownloadTask:
         task.total_bytes = data.get("total_bytes", 0)
         task.progress = data.get("progress", 0.0)
         task.error_message = data.get("error_message", "")
+        task.is_update = data.get("is_update", False)
+        task.update_version = data.get("update_version")
         return task
 
 def get_history_path():
@@ -1047,6 +1056,9 @@ class MainWindow(QMainWindow):
         QTimer.singleShot(1500, self.scheduler_tick)
 
         self._refresh_schedule_indicator()
+
+        # Offer to finish installing an update that was deferred to "next open".
+        QTimer.singleShot(1200, self._check_pending_update)
 
     def closeEvent(self, event):
         save_history(self.tasks)
@@ -1653,31 +1665,54 @@ class MainWindow(QMainWindow):
         except Exception:
             pass
             
+        # Don't queue the same version twice.
+        for t in self.tasks:
+            if getattr(t, "is_update", False) and t.update_version == version:
+                return
+
+        # Add the update to the normal download queue so it downloads through the
+        # proven engine (pause/resume/Range-resume) instead of a fragile modal
+        # downloader. The user starts it like any other task; on completion it
+        # offers to install now or on next launch.
+        task = self._make_update_task(version, download_url)
+        self.add_task_to_ui(task)
+
         dialog = QDialog(self)
         dialog.setWindowTitle(f"Update Available: {version}")
         dialog.setMinimumWidth(500)
-        
+
         layout = QVBoxLayout(dialog)
         layout.addWidget(QLabel(f"<b>A new version ({version}) is available!</b>"))
-        
+        layout.addWidget(QLabel(
+            f'Added to your download queue as "<b>{task.folder_name}</b>". '
+            "Start it now or later — you can pause and resume it like any "
+            "other download."))
+
         text_edit = QTextEdit()
         text_edit.setReadOnly(True)
         text_edit.setMarkdown(changelog)
         layout.addWidget(text_edit)
-        
+
         btn_box = QDialogButtonBox(QDialogButtonBox.StandardButton.Yes | QDialogButtonBox.StandardButton.No)
-        btn_box.button(QDialogButtonBox.StandardButton.Yes).setText("Download and Restart")
+        btn_box.button(QDialogButtonBox.StandardButton.Yes).setText("Start download now")
+        btn_box.button(QDialogButtonBox.StandardButton.No).setText("I'll start it later")
         btn_box.accepted.connect(dialog.accept)
         btn_box.rejected.connect(dialog.reject)
         layout.addWidget(btn_box)
-        
+
         if dialog.exec() == QDialog.DialogCode.Accepted:
-            self.execute_update(download_url)
+            task.status = "Pending"
+            task.error_message = ""
+            task.cancel_flag = False
+            task.pause_flag = False
             
-    def execute_update(self, download_url):
-        dl_dialog = UpdateDownloaderDialog(download_url, self)
-        if dl_dialog.exec() == QDialog.DialogCode.Accepted:
-            zip_path = dl_dialog.temp_zip
+    def _apply_downloaded_update(self, zip_path, version=None):
+        # Apply an already-downloaded release zip: extract it, then hand off to a
+        # batch script that swaps the app directory and restarts (same robust
+        # move -> robocopy -> marker-verify -> rollback flow as before).
+        self.settings.pop("pending_update", None)
+        save_settings(self.settings)
+        if zip_path and os.path.exists(zip_path):
             extract_dir = os.path.join(tempfile.gettempdir(), f"silverspoon_extract_{int(time.time())}")
             
             try:
@@ -1787,6 +1822,71 @@ class MainWindow(QMainWindow):
                 
             except Exception as e:
                 QMessageBox.critical(self, "Update Failed", f"Failed to apply the update:\n{str(e)}")
+        else:
+            QMessageBox.warning(
+                self, "Update",
+                "The downloaded update file is missing. Please download it again.")
+
+    def _make_update_task(self, version, download_url):
+        updates_dir = os.path.expanduser("~/.silverspoon_updates")
+        task = DownloadTask(download_url, updates_dir, f"SilverSpoon Update {version}")
+        task.is_update = True
+        task.update_version = version
+        task.is_selected = True
+        return task
+
+    def _check_update_task_done(self):
+        """When a queued update download finishes, offer to install it. Skips a
+        version already deferred to next-open so it isn't prompted twice."""
+        pending_v = (self.settings.get("pending_update") or {}).get("version")
+        for t in self.tasks:
+            if (getattr(t, "is_update", False) and t.status == "Completed"
+                    and not getattr(t, "_install_handled", False)
+                    and t.update_version != pending_v):
+                t._install_handled = True
+                self._prompt_install(t)
+
+    def _prompt_install(self, task):
+        box = QMessageBox(self)
+        box.setWindowTitle("Update Downloaded")
+        box.setText(
+            f"SilverSpoon {task.update_version} has finished downloading.\n\n"
+            "Install it now (the app will restart), or on the next launch?")
+        now_btn = box.addButton("Install now", QMessageBox.ButtonRole.AcceptRole)
+        later_btn = box.addButton("Install on next open", QMessageBox.ButtonRole.ActionRole)
+        box.addButton("Not yet", QMessageBox.ButtonRole.RejectRole)
+        box.setDefaultButton(now_btn)
+        box.exec()
+        clicked = box.clickedButton()
+        if clicked == now_btn:
+            self._apply_downloaded_update(task.filepath, task.update_version)
+        elif clicked == later_btn:
+            self.settings["pending_update"] = {
+                "zip": task.filepath, "version": task.update_version}
+            save_settings(self.settings)
+            QMessageBox.information(
+                self, "Update Scheduled",
+                f"SilverSpoon {task.update_version} will be installed the next "
+                "time you open the app.")
+
+    def _check_pending_update(self):
+        """On startup, offer to install an update that was deferred earlier."""
+        pending = self.settings.get("pending_update")
+        if not pending:
+            return
+        zip_path, version = pending.get("zip"), pending.get("version")
+        if not zip_path or not os.path.exists(zip_path):
+            self.settings.pop("pending_update", None)
+            save_settings(self.settings)
+            return
+        reply = QMessageBox.question(
+            self, "Install Update",
+            f"SilverSpoon {version} was downloaded earlier and is ready to "
+            "install.\n\nInstall it now? The app will restart.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        if reply == QMessageBox.StandardButton.Yes:
+            self._apply_downloaded_update(zip_path, version)
+        # If No, keep pending_update so it asks again next open.
 
     def open_settings_dialog(self):
         dialog = SettingsDialog(self.settings, self)
@@ -2475,7 +2575,9 @@ class MainWindow(QMainWindow):
             # Store the progress and status in the item's data for the custom delegate to paint
             batch_item.setData(0, Qt.ItemDataRole.UserRole, prog)
             batch_item.setData(1, Qt.ItemDataRole.UserRole, batch_status)
-            
+
+        self._check_update_task_done()
+
     def download_manager(self):
         while True:
             # CAPTCHA resolution belongs to the same worker slot as the actual
@@ -2536,7 +2638,11 @@ class MainWindow(QMainWindow):
         for folder_name, tasks_in_folder in folders.items():
             if folder_name in self.extracted_folders:
                 continue
-                
+
+            # Never auto-extract an app-update download.
+            if any(getattr(t, "is_update", False) for t in tasks_in_folder):
+                continue
+
             valid_extraction_statuses = {"Completed", "Extracted", "Extracting..."}
             if tasks_in_folder and all(t.status in valid_extraction_statuses for t in tasks_in_folder):
                 if all(t.status == "Extracted" for t in tasks_in_folder):
@@ -2688,7 +2794,13 @@ class MainWindow(QMainWindow):
         return None
 
     def download_worker(self, task):
-        dl_url = self.get_direct_link(task)
+        if getattr(task, "is_update", False):
+            # App updates are plain, direct URLs — no Cloudflare/CAPTCHA step.
+            dl_url = task.link
+            task._dl_cookies = {}
+            task._dl_user_agent = ""
+        else:
+            dl_url = self.get_direct_link(task)
         if not dl_url:
             if not task.cancel_flag and not task.pause_flag:
                 if self.settings.get("auto_retry_errors", False) and task.retry_count < 3:

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -11,6 +11,8 @@ import contextlib
 import zipfile
 import shutil
 import uuid
+import urllib.request
+import urllib.error
 from collections import deque
 
 logging.basicConfig(
@@ -1665,9 +1667,11 @@ class MainWindow(QMainWindow):
         except Exception:
             pass
             
-        # Don't queue the same version twice.
+        # Don't queue the same version twice — but a previously failed/cancelled
+        # update shouldn't block re-offering it.
         for t in self.tasks:
-            if getattr(t, "is_update", False) and t.update_version == version:
+            if (getattr(t, "is_update", False) and t.update_version == version
+                    and t.status not in ("Error", "Cancelled")):
                 return
 
         # Add the update to the normal download queue so it downloads through the
@@ -2793,14 +2797,111 @@ class MainWindow(QMainWindow):
             task.error_message = "Could not get the direct download link. The link may be expired or blocked."
         return None
 
+    def _download_update_file(self, task):
+        """Download an app-update file via urllib (stdlib), with resume,
+        pause/cancel and progress. Kept off the shared curl_cffi session, which
+        hangs (curl 28) for a manager-spawned worker that skips get_direct_link."""
+        try:
+            os.makedirs(task.save_dir, exist_ok=True)
+        except Exception as e:
+            task.status = "Error"
+            task.error_message = (
+                f"Failed to create update folder '{task.save_dir}'. "
+                f"{format_error_message(e)}")
+            self.trigger_history_save()
+            return
+
+        initial_size = os.path.getsize(task.filepath) if os.path.exists(task.filepath) else 0
+        req = urllib.request.Request(
+            task.link, headers={"User-Agent": f"SilverSpoon-Updater/{CURRENT_VERSION}"})
+        if initial_size > 0:
+            req.add_header("Range", f"bytes={initial_size}-")
+
+        task.status = "Downloading"
+        task.error_message = ""
+        try:
+            with contextlib.closing(urllib.request.urlopen(req, timeout=30)) as r:
+                status = getattr(r, "status", 200) or 200
+                content_range = r.headers.get("Content-Range")
+                content_length = r.headers.get("Content-Length")
+                if status == 206 and content_range:
+                    m = re.search(r'/([0-9]+)$', content_range)
+                    task.total_bytes = int(m.group(1)) if m else 0
+                    mode = "ab"
+                else:
+                    # Server ignored Range (or none asked) -> full body, restart.
+                    task.total_bytes = int(content_length) if content_length else 0
+                    initial_size = 0
+                    mode = "wb"
+                task.downloaded_bytes = initial_size
+
+                now = time.time()
+                samples = deque([(now, task.downloaded_bytes)])
+                with open(task.filepath, mode) as f:
+                    while True:
+                        if task.pause_flag:
+                            task.status = "Paused"; task.speed = 0; return
+                        if task.cancel_flag:
+                            task.status = "Cancelled"; task.speed = 0; return
+                        chunk = r.read(65536)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        task.downloaded_bytes += len(chunk)
+                        now = time.time()
+                        samples.append((now, task.downloaded_bytes))
+                        while len(samples) > 1 and now - samples[0][0] > 3:
+                            samples.popleft()
+                        w0t, w0b = samples[0]
+                        dur = now - w0t
+                        if dur > 0:
+                            task.speed = ((task.downloaded_bytes - w0b) / dur) / (1024 * 1024)
+                        if task.total_bytes > 0:
+                            task.progress = (task.downloaded_bytes / task.total_bytes) * 100
+
+            task.progress = 100
+            task.speed = 0
+            task.status = "Completed"
+            task.error_message = ""
+            self.trigger_history_save()
+        except urllib.error.HTTPError as he:
+            if he.code == 416 and initial_size > 0:
+                # Range not satisfiable -> the file is already fully downloaded.
+                task.total_bytes = initial_size
+                task.downloaded_bytes = initial_size
+                task.progress = 100
+                task.speed = 0
+                task.status = "Completed"
+                task.error_message = ""
+                self.trigger_history_save()
+                return
+            self._update_download_failed(task, he)
+        except Exception as e:
+            self._update_download_failed(task, e)
+
+    def _update_download_failed(self, task, exc):
+        logging.error("Update download error for %s: %s", task.link, exc, exc_info=True)
+        if task.cancel_flag or task.pause_flag:
+            return
+        if self.settings.get("auto_retry_errors", False) and task.retry_count < 3:
+            task.retry_count += 1
+            task.status = "Pending"
+            task.error_message = ""
+        else:
+            task.status = "Error"
+            task.error_message = f"Update download failed. {format_error_message(exc)}"
+        self.trigger_history_save()
+
     def download_worker(self, task):
         if getattr(task, "is_update", False):
-            # App updates are plain, direct URLs — no Cloudflare/CAPTCHA step.
-            dl_url = task.link
-            task._dl_cookies = {}
-            task._dl_user_agent = ""
-        else:
-            dl_url = self.get_direct_link(task)
+            # App updates are plain, direct URLs downloaded via urllib (stdlib).
+            # The shared curl_cffi session hangs (curl 28) when a manager-spawned
+            # worker uses it for a request that never went through the
+            # nodriver/get_direct_link path first; urllib is unaffected.
+            self._download_update_file(task)
+            return
+
+        dl_url = self.get_direct_link(task)
         if not dl_url:
             if not task.cancel_flag and not task.pause_flag:
                 if self.settings.get("auto_retry_errors", False) and task.retry_count < 3:

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -433,25 +433,10 @@ from update_logic import UpdateCheckerThread
 import datetime as _dt
 import scheduler as offpeak
 from ui_style import button_style
+from providers import needs_resolution, RESOLVER_HOSTS
 
 CURRENT_VERSION = "v1.5.0"
 GITHUB_REPO = "billysams21/SilverSpoon"
-
-# Hosts that hide the file behind a Cloudflare/Turnstile challenge and need the
-# solver to extract a direct link. Every other host is treated as a plain,
-# direct download (fetched straight over HTTP). Keep FuckingFast + DataNodes.
-RESOLVER_HOSTS = ("fuckingfast.co", "datanodes.to")
-
-
-def needs_resolution(link):
-    """True if the link's host needs the Turnstile/CAPTCHA solver."""
-    try:
-        host = urllib.parse.urlparse(link).netloc.lower()
-    except Exception:
-        return False
-    if host.startswith("www."):
-        host = host[4:]
-    return any(host == h or host.endswith("." + h) for h in RESOLVER_HOSTS)
 
 def get_settings_path():
     return os.path.expanduser("~/.silverspoon_settings.json")

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -1667,11 +1667,12 @@ class MainWindow(QMainWindow):
         except Exception:
             pass
             
-        # Don't queue the same version twice — but a previously failed/cancelled
-        # update shouldn't block re-offering it.
+        # Don't queue the same version twice — but re-offer if the previous try
+        # failed/was cancelled, or its downloaded file is gone.
         for t in self.tasks:
             if (getattr(t, "is_update", False) and t.update_version == version
-                    and t.status not in ("Error", "Cancelled")):
+                    and t.status not in ("Error", "Cancelled")
+                    and os.path.exists(t.filepath)):
                 return
 
         # Add the update to the normal download queue so it downloads through the
@@ -1848,7 +1849,8 @@ class MainWindow(QMainWindow):
         for t in self.tasks:
             if (getattr(t, "is_update", False) and t.status == "Completed"
                     and not getattr(t, "_install_handled", False)
-                    and t.update_version != pending_v):
+                    and t.update_version != pending_v
+                    and os.path.exists(t.filepath)):
                 t._install_handled = True
                 self._prompt_install(t)
 

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -1832,8 +1832,10 @@ class MainWindow(QMainWindow):
                 "The downloaded update file is missing. Please download it again.")
 
     def _make_update_task(self, version, download_url):
-        updates_dir = os.path.expanduser("~/.silverspoon_updates")
-        task = DownloadTask(download_url, updates_dir, f"SilverSpoon Update {version}")
+        # Download to the visible Save-To directory, like every other download,
+        # so the user can find it (and it persists for an install-on-next-open).
+        base_dir = os.path.abspath(self.dir_input.text())
+        task = DownloadTask(download_url, base_dir, f"SilverSpoon Update {version}")
         task.is_update = True
         task.update_version = version
         task.is_selected = True

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -342,16 +342,22 @@ class ModernTaskDelegate(QStyledItemDelegate):
                 painter.setFont(font)
                 metrics = painter.fontMetrics()
                 text_w = metrics.horizontalAdvance(status_text)
-                
-                tag_w = text_w + 10
+
+                # Clamp the pill to the column so it never overflows into the
+                # next column; elide the label (e.g. "Solving CAPTCHA...") if it
+                # doesn't fit the available width.
+                max_tag_w = max(24, rect.width() - 6)
+                tag_w = min(text_w + 12, max_tag_w)
                 tag_rect = QRectF(rect.x() + 2, tag_y, tag_w, tag_height)
 
                 painter.setBrush(QBrush(bg_color))
                 painter.setPen(QPen(border_color, 1))
                 painter.drawRoundedRect(tag_rect, 2, 2)
 
+                elided = metrics.elidedText(
+                    status_text, Qt.TextElideMode.ElideRight, int(tag_w) - 8)
                 painter.setPen(text_color)
-                painter.drawText(tag_rect, Qt.AlignmentFlag.AlignCenter, status_text)
+                painter.drawText(tag_rect, Qt.AlignmentFlag.AlignCenter, elided)
                 painter.restore()
                 return
 

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -2910,7 +2910,11 @@ class MainWindow(QMainWindow):
         dl_url = self.get_direct_link(task)
         if not dl_url:
             if not task.cancel_flag and not task.pause_flag:
-                if self.settings.get("auto_retry_errors", False) and task.retry_count < 3:
+                # Don't auto-retry a CAPTCHA timeout: re-solving immediately just
+                # respawns the browser and rarely succeeds.
+                if (self.settings.get("auto_retry_errors", False)
+                        and task.retry_count < 3
+                        and task.status != "CAPTCHA Timeout"):
                     task.retry_count += 1
                     task.status = "Pending"
                     task.error_message = ""

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -441,7 +441,7 @@ import scheduler as offpeak
 from ui_style import button_style
 from providers import needs_resolution, RESOLVER_HOSTS
 
-CURRENT_VERSION = "v1.5.1"
+CURRENT_VERSION = "v1.5.5"
 GITHUB_REPO = "billysams21/SilverSpoon"
 
 def get_settings_path():

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -439,25 +439,10 @@ from update_logic import UpdateCheckerThread
 import datetime as _dt
 import scheduler as offpeak
 from ui_style import button_style
+from providers import needs_resolution, RESOLVER_HOSTS
 
 CURRENT_VERSION = "v1.5.1"
 GITHUB_REPO = "billysams21/SilverSpoon"
-
-# Hosts that hide the file behind a Cloudflare/Turnstile challenge and need the
-# solver to extract a direct link. Every other host is treated as a plain,
-# direct download (fetched straight over HTTP). Keep FuckingFast + DataNodes.
-RESOLVER_HOSTS = ("fuckingfast.co", "datanodes.to")
-
-
-def needs_resolution(link):
-    """True if the link's host needs the Turnstile/CAPTCHA solver."""
-    try:
-        host = urllib.parse.urlparse(link).netloc.lower()
-    except Exception:
-        return False
-    if host.startswith("www."):
-        host = host[4:]
-    return any(host == h or host.endswith("." + h) for h in RESOLVER_HOSTS)
 
 def get_settings_path():
     return os.path.expanduser("~/.silverspoon_settings.json")

--- a/pyqt_downloader.py
+++ b/pyqt_downloader.py
@@ -2925,7 +2925,11 @@ class MainWindow(QMainWindow):
         dl_url = self.get_direct_link(task)
         if not dl_url:
             if not task.cancel_flag and not task.pause_flag:
-                if self.settings.get("auto_retry_errors", False) and task.retry_count < 3:
+                # Don't auto-retry a CAPTCHA timeout: re-solving immediately just
+                # respawns the browser and rarely succeeds.
+                if (self.settings.get("auto_retry_errors", False)
+                        and task.retry_count < 3
+                        and task.status != "CAPTCHA Timeout"):
                     task.retry_count += 1
                     task.status = "Pending"
                     task.error_message = ""

--- a/test_providers.py
+++ b/test_providers.py
@@ -1,0 +1,37 @@
+"""Headless unit checks for provider/host routing. Run: python test_providers.py"""
+import providers as P
+
+
+def test_resolver_hosts_need_resolution():
+    for link in (
+        "https://fuckingfast.co/abc123",
+        "https://www.fuckingfast.co/abc123#file.rar",
+        "https://datanodes.to/xyz",
+        "https://cdn.datanodes.to/d/xyz",
+        "http://fuckingfast.co/x",
+    ):
+        assert P.needs_resolution(link) is True, link
+
+
+def test_general_hosts_are_direct():
+    for link in (
+        "https://example.com/file.zip",
+        "https://github.com/o/r/releases/download/v1/x.zip",
+        "https://objects.githubusercontent.com/x/SilverSpoon.zip",
+        "https://notfuckingfast.co.evil.com/x",
+        "https://mydatanodes.to.example.com/x",
+    ):
+        assert P.needs_resolution(link) is False, link
+
+
+def test_malformed_never_crashes():
+    for bad in ("", "not a url", "ftp://", "://///", "javascript:void"):
+        assert P.needs_resolution(bad) is False, bad
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")

--- a/test_providers.py
+++ b/test_providers.py
@@ -1,0 +1,42 @@
+"""Headless unit checks for provider/host routing. Run: python test_providers.py
+
+Pins the invariant behind the normalized download logic: FuckingFast and
+DataNodes links go through the Turnstile/CAPTCHA solver; every other host is a
+plain direct download.
+"""
+import providers as P
+
+
+def test_resolver_hosts_need_resolution():
+    for link in (
+        "https://fuckingfast.co/abc123",
+        "https://www.fuckingfast.co/abc123#file.rar",
+        "https://datanodes.to/xyz",
+        "https://cdn.datanodes.to/d/xyz",   # subdomain of a resolver host
+        "http://fuckingfast.co/x",
+    ):
+        assert P.needs_resolution(link) is True, link
+
+
+def test_general_hosts_are_direct():
+    for link in (
+        "https://example.com/file.zip",
+        "https://github.com/o/r/releases/download/v1/x.zip",
+        "https://objects.githubusercontent.com/…/SilverSpoon.zip",
+        "https://notfuckingfast.co.evil.com/x",   # not the real host
+        "https://mydatanodes.to.example.com/x",    # not a datanodes.to subdomain
+    ):
+        assert P.needs_resolution(link) is False, link
+
+
+def test_malformed_never_crashes():
+    for bad in ("", "not a url", "ftp://", "://///", None if False else "javascript:void"):
+        assert P.needs_resolution(bad) is False, bad
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")


### PR DESCRIPTION
Supersedes #18, #19, #20, #21 and #22 with a single PR from my fork's `main`, which carries all five on top of v1.5.1 plus the version bump and README update.

**What's in it**
- **fix(updater):** updates download through the normal queue (pause/resume, saves to the Save-To folder, skips the CAPTCHA step). Finished updates offer **Install now** / **Install on next open**; a deferred one is offered again on next launch. Fixes the modal-downloader crash on large releases. (#18)
- **feat(downloads):** any non-Turnstile host is downloaded directly over HTTP with resume/pause/progress. FuckingFast and DataNodes still go through the solver. Host routing lives in `providers.py` with headless unit tests. (#19)
- **fix(solver):** a failed resolution tears the browser down instead of reusing a broken one, so Chromium no longer re-spawns endlessly; CAPTCHA timeouts are not auto-retried. (#20)
- **fix(ui):** the STATUS pill is clamped to its column and elides long labels instead of overflowing into PROGRESS. (#21)
- **ci:** the Windows release workflow now actually produces, verifies and attaches the zip (`contents: write`, Chromium resolved via Playwright's own path, bundle verified before zipping). (#22)
- **release:** `CURRENT_VERSION` → v1.5.5, CHANGELOG dated, README lists the above and documents the exe build.

**Verification**
- `python -m compileall -q .` + all `test_*.py` pass (26 tests); the CI workflow is green on the fork.
- The tag-triggered release build ran end to end on GitHub Actions and attached the zip: https://github.com/arousi/SilverSpoon/releases/tag/v1.5.5
- Installed and launched the built exe on Windows 11.